### PR TITLE
Added check for empty results before commenting on prs

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -161,7 +161,7 @@ async function run (parameters:any){
     let pullRequest = process.env.GITHUB_REF
     let isPR:any = pullRequest?.indexOf("pull")
 
-    if ( isPR >= 1 ){
+    if ( isPR >= 1 && scanCommandOutput.trim() ){
         core.info("This run is part of a PR, should add some PR comment")
 
         const context = github.context


### PR DESCRIPTION
Added check for empty results before commenting on prs. This prevents empty comments like this:
![image](https://user-images.githubusercontent.com/87878295/219696552-454eb3b3-1fee-485b-a6bf-9a377bf11078.png)
