### PR TITLE
Add --include parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ The tool will need some information passed to it as parameters (many are optiona
   * project_ref
   * app_id
   * development_stage
+  * include
 
 * Baseline file
   * if a baseline file should be stored from the scan all paramters are required

--- a/action.yml
+++ b/action.yml
@@ -92,6 +92,9 @@ inputs:
   fail_build:
     description: 'Fail the build upon findings. Takes true or false'
     required: false
+  include: 
+    description: 'Enter a case-sensitive, comma-separated list of name patterns that represent the names of the modules to scan as top-level modules. Veracode identifies these modules during prescan. The * wildcard matches zero or more characters. The ? wildcard matches exactly one character. For example, to include various module names that contain module: --include "module 1, module-*, module2.jar". The scan results show the names of the modules that Veracode identified and the modules included in the scan. This parameter does not pause, stop, or impact the performance of your pipeline.'
+    required: false
   
 runs:
   using: 'node16'

--- a/dist/index.js
+++ b/dist/index.js
@@ -15807,6 +15807,8 @@ const summary_output_file = core.getInput('summary_output_file', { required: fal
 parameters['summary_output_file'] = summary_output_file;
 const json_output = core.getInput('json_output', { required: false });
 parameters['json_output'] = json_output;
+const include = core.getInput('include', { required: false });
+parameters['incude'] = include;
 /*
 const json_output_file = core.getInput('json_output_file', {required: false} );
 parameters['json_output_file'] = json_output_file

--- a/dist/index.js
+++ b/dist/index.js
@@ -15808,7 +15808,7 @@ parameters['summary_output_file'] = summary_output_file;
 const json_output = core.getInput('json_output', { required: false });
 parameters['json_output'] = json_output;
 const include = core.getInput('include', { required: false });
-parameters['incude'] = include;
+parameters['include'] = include;
 /*
 const json_output_file = core.getInput('json_output_file', {required: false} );
 parameters['json_output_file'] = json_output_file

--- a/dist/index.js
+++ b/dist/index.js
@@ -15603,7 +15603,12 @@ function checkParameters(parameters) {
                     core.info('---- DEBUG OUTPUT END ----');
                 }
                 if (key != "debug" && key != "store_baseline_file" && key != "store_baseline_file_branch" && key != "create_baseline_from" && key != "fail_build") {
-                    scanCommand += " --" + key + " " + value;
+                    if (key == "include") {
+                        scanCommand += " --" + key + " '" + value + "'";
+                    }
+                    else {
+                        scanCommand += " --" + key + " " + value;
+                    }
                 }
                 if (parameters.debug == 1) {
                     core.info('---- DEBUG OUTPUT START ----');

--- a/src/check-parameters.ts
+++ b/src/check-parameters.ts
@@ -45,7 +45,12 @@ export async function checkParameters (parameters:any):Promise<string>  {
                  core.info('---- DEBUG OUTPUT END ----')
             }
             if ( key != "debug" && key != "store_baseline_file" && key != "store_baseline_file_branch" && key != "create_baseline_from" && key != "fail_build" ) {
+                if ( key == "include" ){
+                    scanCommand += " --"+key+" '"+value+"'"
+                }
+                else {
                 scanCommand += " --"+key+" "+value
+                }
             }
 
             if (parameters.debug == 1 ){

--- a/src/index.ts
+++ b/src/index.ts
@@ -72,7 +72,7 @@ const json_output = core.getInput('json_output', {required: false} );
 parameters['json_output'] = json_output
 
 const include = core.getInput('include', {required: false} );
-parameters['incude'] = include
+parameters['include'] = include
 
 /*
 const json_output_file = core.getInput('json_output_file', {required: false} );

--- a/src/index.ts
+++ b/src/index.ts
@@ -71,6 +71,9 @@ parameters['summary_output_file'] = summary_output_file
 const json_output = core.getInput('json_output', {required: false} );
 parameters['json_output'] = json_output
 
+const include = core.getInput('include', {required: false} );
+parameters['incude'] = include
+
 /*
 const json_output_file = core.getInput('json_output_file', {required: false} );
 parameters['json_output_file'] = json_output_file


### PR DESCRIPTION
Add --include parameter
Enter a case-sensitive, comma-separated list of name patterns that represent the names of the modules to scan as top-level modules. Veracode identifies these modules during prescan. The * wildcard matches zero or more characters. The ? wildcard matches exactly one character. For example, to include various module names that contain module: --include "module 1, module-*, module2.jar". The scan results show the names of the modules that Veracode identified and the modules included in the scan. This parameter does not pause, stop, or impact the performance of your pipeline.