### PR TITLE
fix(action): correct node version

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -99,5 +99,5 @@ inputs:
     required: false
   
 runs:
-  using: 'node2ß'
+  using: 'node20'
   main: 'dist/index.js'


### PR DESCRIPTION
Correct out of range value

![image](https://github.com/veracode/Veracode-pipeline-scan-action/assets/34628915/9cc74b2b-7070-49eb-904f-a648fa56dcb1)
