### PR TITLE
SDEVX-8414: Enable Platform-Specific Support for actions/artifact Versions (V3 for GHES, V4 for Cloud)

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -107,7 +107,10 @@ inputs:
     description: 'Parameter to check whether request coming from workflow app. Takes true or false'
     required: false 
     default: 'false'
-
+  platformType:
+    description: 'Specifies the platform environment type — use CLOUD for GitHub.com or ENTERPRISE for GitHub Enterprise Server (GHES).'
+    default: 'CLOUD'
+    required: false
 runs:
   using: 'node20'
   main: 'dist/index.js'

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@actions/artifact": "^2.1.4",
+        "@actions/artifact-v1": "npm:@actions/artifact@^1.1.1",
         "@actions/core": "^1.10.0",
         "@actions/github": "^5.1.1",
         "axios": "^1.7.9",
@@ -40,6 +41,19 @@
         "jwt-decode": "^3.1.2",
         "twirp-ts": "^2.5.0",
         "unzip-stream": "^0.3.1"
+      }
+    },
+    "node_modules/@actions/artifact-v1": {
+      "name": "@actions/artifact",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@actions/artifact/-/artifact-1.1.2.tgz",
+      "integrity": "sha512-1gLONA4xw3/Q/9vGxKwkFdV9u1LE2RWGx/IpAqg28ZjprCnJFjwn4pA7LtShqg5mg5WhMek2fjpyH1leCmOlQQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@actions/core": "^1.9.1",
+        "@actions/http-client": "^2.0.1",
+        "tmp": "^0.2.1",
+        "tmp-promise": "^3.0.2"
       }
     },
     "node_modules/@actions/core": {
@@ -1699,6 +1713,24 @@
       "integrity": "sha512-TmLJNj6UgX8xcUZo4UDStGQtDiTzF7BzWlzn9g7UWrjkpHr5uJTK1ld16wZ3LXb2vb6jH8qU89dW5whuMdXYdw==",
       "dependencies": {
         "b4a": "^1.6.4"
+      }
+    },
+    "node_modules/tmp": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
+      "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
+    "node_modules/tmp-promise": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/tmp-promise/-/tmp-promise-3.0.3.tgz",
+      "integrity": "sha512-RwM7MoPojPxsOBYnyd2hy0bxtIlVrihNs9pj5SUvY8Zz1sQcQG2tG1hSr8PDxfgEB8RNKDhqbIlroIarSNDNsQ==",
+      "license": "MIT",
+      "dependencies": {
+        "tmp": "^0.2.0"
       }
     },
     "node_modules/tr46": {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "author": "Veracode",
   "license": "MIT",
   "dependencies": {
+    "@actions/artifact-v1": "npm:@actions/artifact@^1.1.1",
     "@actions/artifact": "^2.1.4",
     "@actions/core": "^1.10.0",
     "@actions/github": "^5.1.1",

--- a/src/index.ts
+++ b/src/index.ts
@@ -121,7 +121,8 @@ parameters['artifact_name'] = artifact_name
 
 const workflow_app = core.getInput('workflow_app', {required: false} );
 
-
+const platformType = core.getInput('platformType', {required: false} );
+parameters['platformType'] = platformType
 
 
 
@@ -177,8 +178,18 @@ async function run (parameters:any){
     
         
         //store output files as artifacts
-        const { DefaultArtifactClient } = require('@actions/artifact')
-        const artifactClient = new DefaultArtifactClient()
+        const { DefaultArtifactClient } = require('@actions/artifact');
+        const artifactV1 = require('@actions/artifact-v1');
+        let artifactClient;
+
+        if (parameters?.platformType === 'ENTERPRISE') {
+            artifactClient = artifactV1.create();
+            core.info(`Using V1 : ${artifactClient}`);
+        } else {
+            artifactClient = new DefaultArtifactClient();
+            core.info(`Using V2 : ${artifactClient}`);
+        }
+
         const artifactName = 'Veracode Pipeline-Scan Results - '+parameters.artifact_name;
         const files = [
             parameters.json_output_file,
@@ -193,6 +204,7 @@ async function run (parameters:any){
         }
 
         try {
+            core.info('Artifact uploading 2 1')
             const uploadResult = await artifactClient.uploadArtifact(artifactName, files, rootDirectory, options)
             core.info('Artifact upload result:')
             core.info(uploadResult)
@@ -226,8 +238,18 @@ async function run (parameters:any){
             core.info('Error creating empty results files')
         }
 
-        const { DefaultArtifactClient } = require('@actions/artifact')
-        const artifactClient = new DefaultArtifactClient()
+        const { DefaultArtifactClient } = require('@actions/artifact');
+        const artifactV1 = require('@actions/artifact-v1');
+        let artifactClient;
+
+        if (parameters?.platformType === 'ENTERPRISE') {
+            artifactClient = artifactV1.create();
+            core.info(`Using V1 : ${artifactClient}`);
+        } else {
+            artifactClient = new DefaultArtifactClient();
+            core.info(`Using V2 : ${artifactClient}`);
+        }
+
         const artifactName = 'Veracode Pipeline-Scan Results - '+parameters.artifact_name;
         const files = [
             parameters.filtered_json_output_file
@@ -240,6 +262,7 @@ async function run (parameters:any){
         }
 
         try {
+            core.info('Artifact uploading 2')
             const uploadResult = await artifactClient.uploadArtifact(artifactName, files, rootDirectory, options)
             core.info('Artifact upload result:')
             core.info(uploadResult)

--- a/src/index.ts
+++ b/src/index.ts
@@ -169,24 +169,24 @@ async function run (parameters:any){
         core.info('---- DEBUG OUTPUT END ----')
     }
 
+    const { DefaultArtifactClient } = require('@actions/artifact');
+    const artifactV1 = require('@actions/artifact-v1');
+    let artifactClient;
+
+    if (platformType === 'ENTERPRISE') {
+        artifactClient = artifactV1.create();
+        core.info(`Initialized the artifact object using version V1.`);
+    } else {
+        artifactClient = new DefaultArtifactClient();
+        core.info(`Initialized the artifact object using version V2.`);
+    }
+
     //check if results files exists and if so store them as artifacts
     if ( existsSync(rootDirectory+'/'+parameters.json_output_file && rootDirectory+'/'+parameters.filtered_json_output_file && rootDirectory+'/'+parameters.summary_output_file) ){
         core.info('Results files exist - storing as artifact')
     
         
         //store output files as artifacts
-        const { DefaultArtifactClient } = require('@actions/artifact');
-        const artifactV1 = require('@actions/artifact-v1');
-        let artifactClient;
-
-        if (platformType === 'ENTERPRISE') {
-            artifactClient = artifactV1.create();
-            core.info(`Using V1 : ${artifactClient}`);
-        } else {
-            artifactClient = new DefaultArtifactClient();
-            core.info(`Using V2 : ${artifactClient}`);
-        }
-
         const artifactName = 'Veracode Pipeline-Scan Results - '+parameters.artifact_name;
         const files = [
             parameters.json_output_file,
@@ -201,7 +201,6 @@ async function run (parameters:any){
         }
 
         try {
-            core.info('Artifact uploading 2 1')
             const uploadResult = await artifactClient.uploadArtifact(artifactName, files, rootDirectory, options)
             core.info('Artifact upload result:')
             core.info(uploadResult)
@@ -235,18 +234,6 @@ async function run (parameters:any){
             core.info('Error creating empty results files')
         }
 
-        const { DefaultArtifactClient } = require('@actions/artifact');
-        const artifactV1 = require('@actions/artifact-v1');
-        let artifactClient;
-
-        if (platformType === 'ENTERPRISE') {
-            artifactClient = artifactV1.create();
-            core.info(`Using V1 : ${artifactClient}`);
-        } else {
-            artifactClient = new DefaultArtifactClient();
-            core.info(`Using V2 : ${artifactClient}`);
-        }
-
         const artifactName = 'Veracode Pipeline-Scan Results - '+parameters.artifact_name;
         const files = [
             parameters.filtered_json_output_file
@@ -259,7 +246,6 @@ async function run (parameters:any){
         }
 
         try {
-            core.info('Artifact uploading 2')
             const uploadResult = await artifactClient.uploadArtifact(artifactName, files, rootDirectory, options)
             core.info('Artifact upload result:')
             core.info(uploadResult)

--- a/src/index.ts
+++ b/src/index.ts
@@ -122,9 +122,6 @@ parameters['artifact_name'] = artifact_name
 const workflow_app = core.getInput('workflow_app', {required: false} );
 
 const platformType = core.getInput('platformType', {required: false} );
-parameters['platformType'] = platformType
-
-
 
 
 async function run (parameters:any){
@@ -182,7 +179,7 @@ async function run (parameters:any){
         const artifactV1 = require('@actions/artifact-v1');
         let artifactClient;
 
-        if (parameters?.platformType === 'ENTERPRISE') {
+        if (platformType === 'ENTERPRISE') {
             artifactClient = artifactV1.create();
             core.info(`Using V1 : ${artifactClient}`);
         } else {
@@ -242,7 +239,7 @@ async function run (parameters:any){
         const artifactV1 = require('@actions/artifact-v1');
         let artifactClient;
 
-        if (parameters?.platformType === 'ENTERPRISE') {
+        if (platformType === 'ENTERPRISE') {
             artifactClient = artifactV1.create();
             core.info(`Using V1 : ${artifactClient}`);
         } else {


### PR DESCRIPTION
Since GHES supports only version V3 of actions/artifact, we’ve added support for both V3 and V4. Based on the platformType parameter, the appropriate actions/artifact object is created, with V4 set as the default for the Cloud environment.