### PR TITLE
add esd parameter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ pipeline-scan-LATEST.zip
 pipeline-scan.jar
 context.json
 helloworld-2.0.jar
+PR_DESCRIPTION.md

--- a/action.yml
+++ b/action.yml
@@ -111,6 +111,9 @@ inputs:
     description: 'Specifies the platform environment type — use CLOUD for GitHub.com or ENTERPRISE for GitHub Enterprise Server (GHES).'
     default: 'CLOUD'
     required: false
+  esd:
+    description: 'Enable ESD (Extended Static Analysis) mode. Takes true or false'
+    required: false
 runs:
   using: 'node20'
   main: 'dist/index.js'

--- a/src/check-parameters.ts
+++ b/src/check-parameters.ts
@@ -140,7 +140,7 @@ export async function checkParameters (parameters:any):Promise<string>  {
         
     core.info('create pipeline-scan scan command')
     Object.entries(parameters).forEach(([key, value], index) => {
-        if ( key != 'vid' && key != 'vkey' && key != 'run_method' && key != 'request_policy' && key != 'veracode_policy_name' && key != 'artifact_name' && value != "") {
+        if ( key != 'vid' && key != 'vkey' && key != 'run_method' && key != 'request_policy' && key != 'veracode_policy_name' && key != 'artifact_name' && key != 'esd' && value != "") {
                 
             if (parameters.debug == 1 ){
                 core.info('---- DEBUG OUTPUT START ----')
@@ -148,7 +148,7 @@ export async function checkParameters (parameters:any):Promise<string>  {
                 core.info('---- Parameter: '+key+' value: '+value)
                  core.info('---- DEBUG OUTPUT END ----')
             }
-            if ( key != "debug" && key != "store_baseline_file" && key != "store_baseline_file_branch" && key != "create_baseline_from" && key != "fail_build" ) {
+            if ( key != "debug" && key != "store_baseline_file" && key != "store_baseline_file_branch" && key != "create_baseline_from" && key != "fail_build" && key != "esd" ) {
                 if ( key == "include" ){
                     scanCommand += " --"+key+" '"+value+"'"
                 }
@@ -166,6 +166,16 @@ export async function checkParameters (parameters:any):Promise<string>  {
         }
     });
 
+    // Add ESD parameter if enabled
+    if ( parameters.esd == "true" || parameters.esd == true ){
+        scanCommand += ' -esd true'
+        if (parameters.debug == 1 ){
+            core.info('---- DEBUG OUTPUT START ----')
+            core.info('---- check-parameters.ts / checkParameters() - ESD enabled ----')
+            core.info('---- Added -esd true to scan command')
+            core.info('---- DEBUG OUTPUT END ----')
+        }
+    }    
 
 
     if (parameters.debug == 1 ){

--- a/src/index.ts
+++ b/src/index.ts
@@ -123,6 +123,10 @@ const workflow_app = core.getInput('workflow_app', {required: false} );
 
 const platformType = core.getInput('platformType', {required: false} );
 
+const esd = core.getInput('esd', {required: false} );
+parameters['esd'] = esd
+//true or false 
+
 
 async function run (parameters:any){
     downloadJar()


### PR DESCRIPTION
# Add ESD Parameter Support and Improve API Request Handling

## Summary
This PR adds support for the Extended Static Analysis (ESD) parameter

## Changes

### ✨ New Features

#### 1. ESD Parameter Support
- Added new `esd` input parameter to enable Extended Static Analysis mode
- When `esd` is set to `true`, the pipeline-scan command will include `-esd true`
- Parameter is properly excluded from the automatic parameter loop and handled separately
- Includes debug logging when ESD is enabled

**Files Modified:**
- `action.yml` - Added `esd` input parameter definition
- `src/index.ts` - Added `esd` parameter reading and assignment
- `src/check-parameters.ts` - Added logic to append `-esd true` to scan command when enabled

## Usage

### ESD Parameter
To enable Extended Static Analysis mode, add the `esd` parameter to your workflow:

```yaml
- name: Veracode Pipeline Scan
  uses: veracode/veracode-pipeline-scan-action@v1
  with:
    vid: ${{ secrets.VID }}
    vkey: ${{ secrets.VKEY }}
    file: 'application.zip'
    esd: 'true'  # Enable Extended Static Analysis
```

## Breaking Changes
None - this is a backward-compatible addition.

